### PR TITLE
Helm test should run against the readiness endpoint for now.

### DIFF
--- a/deploy/helm/templates/tests/test-connection.yaml
+++ b/deploy/helm/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "alertmanager-discord.fullname" . }}:{{ .Values.service.port }}']
+      args: ['{{ include "alertmanager-discord.fullname" . }}:{{ .Values.service.port }}/readiness']
   restartPolicy: Never


### PR DESCRIPTION
- the root endpoint with a blank body results in a 400 Bad Request response, which is appropriate.  This means that the helm test in its current form fails.
- Helm test should use readiness endpoint.